### PR TITLE
Problem with access controll in RTFM

### DIFF
--- a/html/RTFM/Article/PreCreate.html
+++ b/html/RTFM/Article/PreCreate.html
@@ -53,9 +53,11 @@
 % $Classes->LimitToEnabled();
 % my $have_classes = 0;
 % while (my $Class = $Classes->Next) {
+% if ( $Class->CurrentUserHasRight('CreateArticle') ) {
 % $have_classes++;
 % my $qs = $m->comp("/Elements/QueryString", %ARGS, Class=> $Class->Id);
 <li><a href="Edit.html?<% $qs|n %>"><&|/l, $Class->Name &>in class [_1]</&></a></li>
+% }
 % }
 </ul>
 % unless ( $have_classes ) {


### PR DESCRIPTION
Hello,

I noticed that even if my user didn't have CreateArticle for a specific class he could still select and create articles. I traced the problem and it seems like there has been a refactoring of the code, the element SelectClass is no longer used (and it checks the CreateArticle permission) while the code in PreCreate.html doesn't. I am not 100% sure that this is the way to solve the problem since I am not that well versed in RTFM codebase yet. Please point me in the right direction to solve the problem in that case.

Thanks,
Tobias
